### PR TITLE
RBAC-based tab completion for the CLI commands

### DIFF
--- a/build/src/main/resources/bin/jboss-cli-logging.properties
+++ b/build/src/main/resources/bin/jboss-cli-logging.properties
@@ -21,8 +21,9 @@
 #
 
 # Additional logger names to configure (root logger is always configured)
-loggers=org,org.jboss.as.cli
+loggers=org,javax,org.jboss.as.cli
 logger.org.level=OFF
+logger.javax.level=OFF
 # assign a lower level to enable CLI logging
 logger.org.jboss.as.cli.level=OFF
 

--- a/build/src/main/resources/bin/jboss-cli.xml
+++ b/build/src/main/resources/bin/jboss-cli.xml
@@ -3,7 +3,7 @@
 <!--
    WildFly Command-line Interface configuration.
 -->
-<jboss-cli xmlns="urn:jboss:cli:2.0">
+<jboss-cli xmlns="urn:jboss:cli:2.1">
 
     <!-- The default controller to connect to when 'connect' command is executed w/o arguments -->
     <default-controller>
@@ -28,4 +28,7 @@
 
     <!-- Whether to write info and error messages to the terminal output -->
     <silent>false</silent>
+
+    <!-- Whether to filter out commands and attributes based on user's roles -->
+    <access-control>false</access-control>
 </jboss-cli>

--- a/build/src/main/resources/docs/schema/jboss-as-cli_2_1.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-cli_2_1.xsd
@@ -1,0 +1,168 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2012, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns="urn:jboss:cli:2.1"
+           targetNamespace="urn:jboss:cli:2.1"
+           elementFormDefault="qualified"
+           attributeFormDefault="unqualified"
+        >
+
+
+    <xs:element name="jboss-cli">
+        <xs:annotation>
+            <xs:documentation>
+                Root element for the JBoss Command Line Interface configuration.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="default-controller" minOccurs="0"/>
+                <xs:element ref="validate-operation-requests" minOccurs="0"/>
+                <xs:element ref="history" minOccurs="0"/>
+
+                <xs:element name="resolve-parameter-values" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Whether to resolve system properties specified as command argument (or operation parameter)
+                            values before sending the operation request to the controller or let the resolution happen
+                            on the server side.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+
+                <xs:element ref="connection-timeout" minOccurs="0" maxOccurs="1"/>
+
+                <xs:element ref="ssl" minOccurs="0" maxOccurs="1"/>
+
+                <xs:element ref="silent" minOccurs="0" maxOccurs="1"/>
+
+                <xs:element ref="access-control" minOccurs="0" maxOccurs="1"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="default-controller">
+        <xs:annotation>
+            <xs:documentation>
+                This element contains the configuration of the default controller to connect to
+                when the connect command is executed w/o arguments.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="protocol" type="xs:string" minOccurs="0" default="http-remoting"/>
+                <xs:element name="host" type="xs:string" minOccurs="0" default="localhost"/>
+                <xs:element name="port" type="xs:int" minOccurs="0" default="9990"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="validate-operation-requests" type="xs:boolean" default="true">
+        <xs:annotation>
+            <xs:documentation>
+                Indicates whether the parameter list of the operation reuqests
+                should be validated before the requests are sent to the controller
+                for the execution.
+            </xs:documentation>
+        </xs:annotation>
+    </xs:element>
+
+    <xs:element name="history">
+        <xs:annotation>
+            <xs:documentation>
+                This element contains the configuration for the commands and operations history log.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="enabled" type="xs:boolean" minOccurs="0" default="true"/>
+                <xs:element name="file-name" type="xs:string" minOccurs="0" default=".jboss-cli-history"/>
+                <xs:element name="file-dir" type="xs:string" minOccurs="0" default="${user.home}"/>
+                <xs:element name="max-size" type="xs:int" minOccurs="0" default="500"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="connection-timeout" type="xs:int" default="5000">
+        <xs:annotation>
+            <xs:documentation>
+                The time allowed to establish a connection with the controller.
+            </xs:documentation>
+        </xs:annotation>
+    </xs:element>
+
+    <xs:element name="ssl">
+        <xs:annotation>
+            <xs:documentation>
+                This element contains the configuration for the Key and Trust stores
+                used for SSL.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="key-store" type="xs:string" minOccurs="0" />
+                <xs:element name="key-store-password" type="xs:string" minOccurs="0" />
+                <xs:element name="alias" type="xs:string" minOccurs="0" />
+                <xs:element name="key-password" type="xs:string" minOccurs="0" />
+                <xs:element name="trust-store" type="xs:string" minOccurs="0" />
+                <xs:element name="trust-store-password" type="xs:string" minOccurs="0" />
+                <xs:element name="modify-trust-store" type="xs:boolean" default="true" minOccurs="0">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Setting to true will cause the CLI to prompt when unrecognised certificates are received
+                            and allow them to be stored in the truststore.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="silent" type="xs:boolean" default="false">
+        <xs:annotation>
+            <xs:documentation>
+                Whether to write info and error messages to the terminal output.
+                Even if the value is false, the messages will still be logged
+                using the logger if its configuration allows and/or if the
+                output target was specified as part of the command line using '>'.
+            </xs:documentation>
+        </xs:annotation>
+    </xs:element>
+
+    <xs:element name="access-control" type="xs:boolean" default="true">
+        <xs:annotation>
+            <xs:documentation>
+                Whether the management-related commands and attributes should be 
+                filtered for the current user based on the permissions the user
+                has been granted. In other words, if access-control is true,
+                the tab-completion will hide commands and attributes the user
+                is not allowed to access.
+                In case the user attempts to execute a command or an operation
+                without having sufficient permissions to do so, regardless of the value
+                this element has, the attempt will fail with an access control error. 
+            </xs:documentation>
+        </xs:annotation>
+    </xs:element>
+</xs:schema>

--- a/cli/src/main/java/org/jboss/as/cli/CliConfig.java
+++ b/cli/src/main/java/org/jboss/as/cli/CliConfig.java
@@ -129,4 +129,13 @@ public interface CliConfig {
      * @return
      */
     boolean isSilent();
+
+    /**
+     * Whether the role based access control should be used
+     * to check the availability of the commands (for tab-completion).
+     *
+     * @return  true if command availability checks should include RBAC,
+     *          otherwise - false
+     */
+    boolean isAccessControl();
 }

--- a/cli/src/main/java/org/jboss/as/cli/accesscontrol/AccessRequirement.java
+++ b/cli/src/main/java/org/jboss/as/cli/accesscontrol/AccessRequirement.java
@@ -1,0 +1,45 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.cli.accesscontrol;
+
+import org.jboss.as.cli.CommandContext;
+
+/**
+ * @author Alexey Loubyansky
+ *
+ */
+public interface AccessRequirement {
+
+    boolean isSatisfied(CommandContext ctx);
+
+    AccessRequirement NONE = new AccessRequirement() {
+        @Override
+        public boolean isSatisfied(CommandContext ctx) {
+            return true;
+        }
+        @Override
+        public String toString(){
+            return "none";
+        }
+    };
+}

--- a/cli/src/main/java/org/jboss/as/cli/accesscontrol/AccessRequirementBuilder.java
+++ b/cli/src/main/java/org/jboss/as/cli/accesscontrol/AccessRequirementBuilder.java
@@ -1,0 +1,343 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.cli.accesscontrol;
+
+import org.jboss.as.cli.CommandContext;
+import org.jboss.as.cli.Util;
+import org.jboss.as.cli.operation.OperationRequestAddress;
+
+/**
+ * @author Alexey Loubyansky
+ *
+ */
+public interface AccessRequirementBuilder {
+
+    interface RequirementSetBuilder extends AccessRequirementBuilder {
+
+        RequirementSetBuilder operation(String operation);
+
+        RequirementSetBuilder operation(String address, String operation);
+
+        RequirementSetBuilder serverGroupOperation(String operation);
+
+        RequirementSetBuilder serverGroupOperation(String address, String operation);
+
+        RequirementSetBuilder profileOperation(String address, String operation);
+
+        RequirementSetBuilder operation(OperationRequestAddress address, String operation);
+
+        RequirementSetBuilder serverGroupOperation(OperationRequestAddress address, String operation);
+
+        RequirementSetBuilder profileOperation(OperationRequestAddress address, String operation);
+
+        RequirementSetBuilder hostServerOperation(String address, String operation);
+
+        RequirementSetBuilder requirement(AccessRequirement requirement);
+    }
+
+    RequirementSetBuilder all();
+
+    RequirementSetBuilder any();
+
+    AccessRequirementBuilder domain();
+
+    AccessRequirementBuilder standalone();
+
+    AccessRequirementBuilder parent();
+
+    AccessRequirement build();
+
+    class Factory {
+        public static AccessRequirementBuilder create(final CommandContext ctx) {
+            return new AccessRequirementBuilder() {
+
+                AccessRequirementBuilder builder;
+
+                @Override
+                public RequirementSetBuilder all() {
+                    if(builder != null) {
+                        throw new IllegalStateException("The builder has been initialized: " + builder);
+                    }
+                    builder = new AllRequiredBuilder(this, ctx);
+                    return (RequirementSetBuilder) builder;
+                }
+
+                @Override
+                public RequirementSetBuilder any() {
+                    if(builder != null) {
+                        throw new IllegalStateException("The builder has been initialized: " + builder);
+                    }
+                    builder = new AnyRequiredBuilder(this, ctx);
+                    return (RequirementSetBuilder) builder;
+                }
+
+                @Override
+                public RequirementSetBuilder domain() {
+                    if(builder != null) {
+                        throw new IllegalStateException("The builder has been initialized: " + builder);
+                    }
+                    builder = new DomainModeRequirementBuilder(this, ctx);
+                    return (RequirementSetBuilder) builder;
+                }
+
+                @Override
+                public RequirementSetBuilder standalone() {
+                    if(builder != null) {
+                        throw new IllegalStateException("The builder has been initialized: " + builder);
+                    }
+                    builder = new StandaloneModeRequirementBuilder(this, ctx);
+                    return (RequirementSetBuilder) builder;
+                }
+
+                @Override
+                public AccessRequirementBuilder parent() {
+                    throw new IllegalStateException();
+                }
+
+                @Override
+                public AccessRequirement build() {
+                    return builder == null ? AccessRequirement.NONE : builder.build();
+                }
+            };
+        }
+
+        private static class AllRequiredBuilder extends BaseRequirementSetBuilder {
+
+            AllRequiredBuilder(AccessRequirementBuilder parent, CommandContext ctx) {
+                super(parent, ctx);
+            }
+
+            @Override
+            protected AccessRequirementSet createTarget() {
+                return new AllRequiredSet();
+            }
+        }
+
+        private static class AnyRequiredBuilder extends BaseRequirementSetBuilder {
+
+            AnyRequiredBuilder(AccessRequirementBuilder parent, CommandContext ctx) {
+                super(parent, ctx);
+            }
+
+            @Override
+            protected AccessRequirementSet createTarget() {
+                return new AnyRequiredSet();
+            }
+        }
+
+        private abstract static class BaseRequirementSetBuilder implements RequirementSetBuilder {
+
+            protected final AccessRequirementBuilder parent;
+            protected final AccessRequirementSet set;
+            protected final CommandContext ctx;
+
+            BaseRequirementSetBuilder(AccessRequirementBuilder parent, CommandContext ctx) {
+                this.parent = parent;
+                set = createTarget();
+                this.ctx = ctx;
+                ctx.addEventListener(set);
+            }
+
+            protected abstract AccessRequirementSet createTarget();
+
+            @Override
+            public RequirementSetBuilder all() {
+                final AllRequiredBuilder nested = new AllRequiredBuilder(this, ctx);
+                set.add(nested.set);
+                return nested;
+            }
+
+            @Override
+            public RequirementSetBuilder any() {
+                final AnyRequiredBuilder nested = new AnyRequiredBuilder(this, ctx);
+                set.add(nested.set);
+                return nested;
+            }
+
+            @Override
+            public AccessRequirementBuilder domain() {
+                final DomainModeRequirementBuilder nested = new DomainModeRequirementBuilder(this, ctx);
+                set.add(nested.modeReq);
+                return nested;
+            }
+
+            @Override
+            public AccessRequirementBuilder standalone() {
+                final StandaloneModeRequirementBuilder nested = new StandaloneModeRequirementBuilder(this, ctx);
+                set.add(nested.modeReq);
+                return nested;
+            }
+
+            @Override
+            public RequirementSetBuilder operation(String operation) {
+                return add(new MainOperationAccessRequirement(operation));
+            }
+
+            @Override
+            public RequirementSetBuilder operation(OperationRequestAddress address, String operation) {
+                return add(new MainOperationAccessRequirement(address, operation));
+            }
+
+            @Override
+            public RequirementSetBuilder serverGroupOperation(String operation) {
+                return add(new PerNodeOperationAccess(Util.SERVER_GROUP, operation));
+            }
+
+            @Override
+            public RequirementSetBuilder serverGroupOperation(OperationRequestAddress address, String operation) {
+                return add(new PerNodeOperationAccess(Util.SERVER_GROUP, address, operation));
+            }
+
+            @Override
+            public RequirementSetBuilder profileOperation(OperationRequestAddress address, String operation) {
+                return add(new PerNodeOperationAccess(Util.PROFILE, address, operation));
+            }
+
+            @Override
+            public RequirementSetBuilder operation(String address, String operation) {
+                return add(new MainOperationAccessRequirement(address, operation));
+            }
+
+            @Override
+            public RequirementSetBuilder serverGroupOperation(String address, String operation) {
+                return add(new PerNodeOperationAccess(Util.SERVER_GROUP, address, operation));
+            }
+
+            @Override
+            public RequirementSetBuilder profileOperation(String address, String operation) {
+                return add(new PerNodeOperationAccess(Util.PROFILE, address, operation));
+            }
+
+            @Override
+            public RequirementSetBuilder hostServerOperation(String address, String operation) {
+                return add(new HostServerOperationAccess(address, operation));
+            }
+
+            @Override
+            public RequirementSetBuilder requirement(AccessRequirement requirement) {
+                if(requirement == null) {
+                    throw new IllegalArgumentException("requirement is null");
+                }
+                set.add(requirement);
+                return this;
+            }
+
+            @Override
+            public AccessRequirementBuilder parent() {
+                return parent;
+            }
+
+            protected RequirementSetBuilder add(final BaseOperationAccessRequirement op) {
+                set.add(op);
+                ctx.addEventListener(op);
+                return this;
+            }
+
+            @Override
+            public AccessRequirement build() {
+                return set;
+            }
+        }
+
+        private static class DomainModeRequirementBuilder extends ControllerModeRequirementBuilder {
+
+            DomainModeRequirementBuilder(AccessRequirementBuilder parent, CommandContext ctx) {
+                super(parent, ctx);
+            }
+
+            @Override
+            protected ControllerModeAccess createModeAccess() {
+                return new ControllerModeAccess(ControllerModeAccess.Mode.DOMAIN);
+            }
+        }
+
+        private static class StandaloneModeRequirementBuilder extends ControllerModeRequirementBuilder {
+
+            StandaloneModeRequirementBuilder(AccessRequirementBuilder parent, CommandContext ctx) {
+                super(parent, ctx);
+            }
+
+            @Override
+            protected ControllerModeAccess createModeAccess() {
+                return new ControllerModeAccess(ControllerModeAccess.Mode.STANDALONE);
+            }
+        }
+
+        private abstract static class ControllerModeRequirementBuilder implements AccessRequirementBuilder {
+
+            protected final AccessRequirementBuilder parent;
+            protected final ControllerModeAccess modeReq;
+            protected final CommandContext ctx;
+            protected BaseRequirementSetBuilder nestedSet;
+
+            ControllerModeRequirementBuilder(AccessRequirementBuilder parent, CommandContext ctx) {
+                this.parent = parent;
+                this.ctx = ctx;
+                modeReq = createModeAccess();
+                ctx.addEventListener(modeReq);
+            }
+
+            protected abstract ControllerModeAccess createModeAccess();
+
+            @Override
+            public RequirementSetBuilder all() {
+                if(nestedSet != null) {
+                    throw new IllegalStateException("The nested set has been initialized.");
+                }
+                nestedSet = new AllRequiredBuilder(this, ctx);
+                modeReq.setRequirement(nestedSet.set);
+                return nestedSet;
+            }
+
+            @Override
+            public RequirementSetBuilder any() {
+                if(nestedSet != null) {
+                    throw new IllegalStateException("The nested set has been initialized.");
+                }
+                nestedSet = new AnyRequiredBuilder(this, ctx);
+                modeReq.setRequirement(nestedSet.set);
+                return nestedSet;
+            }
+
+            @Override
+            public RequirementSetBuilder domain() {
+                throw new IllegalStateException();
+            }
+
+            @Override
+            public RequirementSetBuilder standalone() {
+                throw new IllegalStateException();
+            }
+
+            @Override
+            public AccessRequirementBuilder parent() {
+                return parent;
+            }
+
+            @Override
+            public AccessRequirement build() {
+                return modeReq;
+            }
+        }
+    }
+}

--- a/cli/src/main/java/org/jboss/as/cli/accesscontrol/AccessRequirementSet.java
+++ b/cli/src/main/java/org/jboss/as/cli/accesscontrol/AccessRequirementSet.java
@@ -1,0 +1,63 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.cli.accesscontrol;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+
+/**
+ * @author Alexey Loubyansky
+ *
+ */
+public abstract class AccessRequirementSet extends BaseAccessRequirement {
+
+    protected List<AccessRequirement> requirements = Collections.emptyList();
+
+    public void add(AccessRequirement requirement) {
+        if(requirement == null) {
+            throw new IllegalArgumentException("Requirement is null");
+        }
+
+        if(requirements.isEmpty()) {
+            requirements = Collections.singletonList(requirement);
+        } else {
+            if (requirements.size() == 1) {
+                final List<AccessRequirement> tmp = requirements;
+                requirements = new ArrayList<AccessRequirement>();
+                requirements.addAll(tmp);
+            }
+            requirements.add(requirement);
+        }
+    }
+
+    private String toString;
+    @Override
+    public String toString() {
+        if(toString == null) {
+            toString = requirements.toString();
+        }
+        return toString;
+    }
+}

--- a/cli/src/main/java/org/jboss/as/cli/accesscontrol/AddressAccessRequirement.java
+++ b/cli/src/main/java/org/jboss/as/cli/accesscontrol/AddressAccessRequirement.java
@@ -1,0 +1,66 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.cli.accesscontrol;
+
+import org.jboss.as.cli.CommandFormatException;
+import org.jboss.as.cli.operation.CommandLineParser;
+import org.jboss.as.cli.operation.OperationRequestAddress;
+import org.jboss.as.cli.operation.impl.DefaultCallbackHandler;
+import org.jboss.as.cli.operation.impl.DefaultOperationRequestAddress;
+import org.jboss.as.cli.parsing.ParserUtil;
+
+/**
+ * @author Alexey Loubyansky
+ *
+ */
+public abstract class AddressAccessRequirement extends BaseAccessRequirement {
+
+    protected final OperationRequestAddress address;
+
+    AddressAccessRequirement() {
+        address = new DefaultOperationRequestAddress();
+    }
+
+    AddressAccessRequirement(String address) {
+        this.address = new DefaultOperationRequestAddress();
+        if (address != null) {
+            final CommandLineParser.CallbackHandler handler = new DefaultCallbackHandler(this.address);
+            try {
+                ParserUtil.parseOperationRequest(address, handler);
+            } catch (CommandFormatException e) {
+                throw new IllegalArgumentException("Failed to parse path '" + address + "': " + e.getMessage());
+            }
+        }
+    }
+
+    AddressAccessRequirement(OperationRequestAddress address) {
+        if(address == null) {
+            throw new IllegalArgumentException("address is null");
+        }
+        this.address = address;
+    }
+
+    protected OperationRequestAddress getAddress() {
+        return address;
+    }
+}

--- a/cli/src/main/java/org/jboss/as/cli/accesscontrol/AllRequiredSet.java
+++ b/cli/src/main/java/org/jboss/as/cli/accesscontrol/AllRequiredSet.java
@@ -1,0 +1,45 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.cli.accesscontrol;
+
+import org.jboss.as.cli.CommandContext;
+
+/**
+ * @author Alexey Loubyansky
+ *
+ */
+public class AllRequiredSet extends AccessRequirementSet {
+
+    /* (non-Javadoc)
+     * @see org.jboss.as.cli.accesscontrol.BaseAccessRequirement#checkAccess(org.jboss.as.cli.CommandContext)
+     */
+    @Override
+    protected boolean checkAccess(CommandContext ctx) {
+        for(AccessRequirement req : requirements) {
+            if(!req.isSatisfied(ctx)) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/cli/src/main/java/org/jboss/as/cli/accesscontrol/AnyRequiredSet.java
+++ b/cli/src/main/java/org/jboss/as/cli/accesscontrol/AnyRequiredSet.java
@@ -1,0 +1,45 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.cli.accesscontrol;
+
+import org.jboss.as.cli.CommandContext;
+
+/**
+ * @author Alexey Loubyansky
+ *
+ */
+public class AnyRequiredSet extends AccessRequirementSet {
+
+    /* (non-Javadoc)
+     * @see org.jboss.as.cli.accesscontrol.BaseAccessRequirement#checkAccess(org.jboss.as.cli.CommandContext)
+     */
+    @Override
+    protected boolean checkAccess(CommandContext ctx) {
+        for(AccessRequirement req : requirements) {
+            if(req.isSatisfied(ctx)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/cli/src/main/java/org/jboss/as/cli/accesscontrol/BaseAccessRequirement.java
+++ b/cli/src/main/java/org/jboss/as/cli/accesscontrol/BaseAccessRequirement.java
@@ -1,0 +1,65 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.cli.accesscontrol;
+
+import org.jboss.as.cli.CliEvent;
+import org.jboss.as.cli.CliEventListener;
+import org.jboss.as.cli.CommandContext;
+import org.jboss.logging.Logger;
+
+
+/**
+ * @author Alexey Loubyansky
+ *
+ */
+public abstract class BaseAccessRequirement implements AccessRequirement, CliEventListener {
+
+    protected Logger log = Logger.getLogger(getClass());
+    protected final boolean traceEnabled = log.isTraceEnabled();
+
+    private Boolean satisfied;
+
+    @Override
+    public boolean isSatisfied(CommandContext ctx) {
+        if(satisfied == null) {
+            satisfied = checkAccess(ctx);
+            if(traceEnabled) {
+                log.trace(toString() + " " + satisfied);
+            }
+        }
+        return satisfied;
+    }
+
+    @Override
+    public void cliEvent(CliEvent event, CommandContext ctx) {
+        if(event == CliEvent.DISCONNECTED) {
+            satisfied = null;
+            resetState();
+        }
+    }
+
+    protected void resetState() {
+    }
+
+    protected abstract boolean checkAccess(CommandContext ctx);
+}

--- a/cli/src/main/java/org/jboss/as/cli/accesscontrol/BaseOperationAccessRequirement.java
+++ b/cli/src/main/java/org/jboss/as/cli/accesscontrol/BaseOperationAccessRequirement.java
@@ -1,0 +1,70 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.cli.accesscontrol;
+
+import org.jboss.as.cli.operation.OperationRequestAddress;
+import org.jboss.as.cli.operation.impl.DefaultOperationRequestAddress;
+import org.jboss.as.cli.operation.impl.DefaultPrefixFormatter;
+
+/**
+ * @author Alexey Loubyansky
+ *
+ */
+public abstract class BaseOperationAccessRequirement extends AddressAccessRequirement {
+
+    protected final String operation;
+
+    BaseOperationAccessRequirement(String operation) {
+        this(new DefaultOperationRequestAddress(), operation);
+    }
+
+    BaseOperationAccessRequirement(String address, String operation) {
+        super(address);
+        if(operation == null) {
+            throw new IllegalArgumentException("operation is null");
+        }
+        this.operation = operation;
+    }
+
+    BaseOperationAccessRequirement(OperationRequestAddress address, String operation) {
+        super(address);
+        if(operation == null) {
+            throw new IllegalArgumentException("operation is null");
+        }
+        this.operation = operation;
+    }
+
+    protected String toString;
+    @Override
+    public String toString() {
+        if (toString == null) {
+            final StringBuilder buf = new StringBuilder();
+            if (address != null) {
+                buf.append(DefaultPrefixFormatter.INSTANCE.format(address));
+            }
+            buf.append(':').append(operation);
+            toString = buf.toString();
+        }
+        return toString;
+    }
+}

--- a/cli/src/main/java/org/jboss/as/cli/accesscontrol/CLIAccessControl.java
+++ b/cli/src/main/java/org/jboss/as/cli/accesscontrol/CLIAccessControl.java
@@ -1,0 +1,162 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.cli.accesscontrol;
+
+import java.util.Iterator;
+
+import org.jboss.as.cli.Util;
+import org.jboss.as.cli.operation.OperationRequestAddress;
+import org.jboss.as.cli.operation.OperationRequestAddress.Node;
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.dmr.ModelNode;
+import org.jboss.logging.Logger;
+
+/**
+ * @author Alexey Loubyansky
+ *
+ */
+public class CLIAccessControl {
+
+    private static final Logger log = Logger.getLogger(CLIAccessControl.class);
+
+    public static boolean isExecute(ModelControllerClient client, OperationRequestAddress address, String operation) {
+        return isExecute(client, null, address, operation);
+    }
+
+    public static boolean isExecute(ModelControllerClient client, String[] parent, OperationRequestAddress address, String operation) {
+        final ModelNode accessControl = getAccessControl(client, parent, address, true);
+        if(accessControl == null) {
+            return false;
+        }
+
+        if(!accessControl.has(Util.DEFAULT)) {
+            log.warn("access-control is missing defaults: " + accessControl);
+            return false;
+        }
+
+        final ModelNode defaults = accessControl.get(Util.DEFAULT);
+        if(!defaults.has(Util.OPERATIONS)) {
+            log.warn("access-control/default is missing operations: " + accessControl);
+            return false;
+        }
+
+        final ModelNode operations = defaults.get(Util.OPERATIONS);
+        if(!operations.has(operation)) {
+            if(log.isTraceEnabled()) {
+                log.trace("The operation is missing in the description: " + operation);
+            }
+            return false;
+        }
+
+        final ModelNode opAC = operations.get(operation);
+        if(!opAC.has(Util.EXECUTE)) {
+            log.warn("'execute' is missing for " + operation + " in " + accessControl);
+            return false;
+        }
+
+        return opAC.get(Util.EXECUTE).asBoolean();
+    }
+
+    /**
+     * Executed read-resource-description and returns access-control info.
+     * Returns null in case there was any kind of problem.
+     *
+     * @param client
+     * @param address
+     * @return
+     */
+    public static ModelNode getAccessControl(ModelControllerClient client, OperationRequestAddress address, boolean operations) {
+        return getAccessControl(client, null, address, operations);
+    }
+
+    public static ModelNode getAccessControl(ModelControllerClient client, String[] parent, OperationRequestAddress address, boolean operations) {
+
+        if(client == null) {
+            return null;
+        }
+
+        if(address.endsOnType()) {
+            log.debug("The prefix ends on a type.");
+            return null;
+        }
+
+        final ModelNode request = new ModelNode();
+        setAddress(request, parent, address);
+        request.get(Util.OPERATION).set(Util.READ_RESOURCE_DESCRIPTION);
+        request.get(Util.ACCESS_CONTROL).set(Util.TRIM_DESCRIPTIONS);
+        if(operations) {
+            request.get(Util.OPERATIONS).set(true);
+        }
+
+        final ModelNode response;
+        try {
+            response = client.execute(request);
+        } catch (Exception e) {
+            log.warn("Failed to execute " + Util.READ_RESOURCE_DESCRIPTION, e);
+            return null;
+        }
+
+        if (!Util.isSuccess(response)) {
+            log.debug("Failed to execute " + Util.READ_RESOURCE_DESCRIPTION + ": " + response);
+            return null;
+        }
+
+        if(!response.has(Util.RESULT)) {
+            log.warn("Response is missing result for " + Util.READ_RESOURCE_DESCRIPTION + ": " + response);
+            return null;
+        }
+
+        final ModelNode result = response.get(Util.RESULT);
+        if(!result.has(Util.ACCESS_CONTROL)) {
+            log.warn("Result is missing access-control for " + Util.READ_RESOURCE_DESCRIPTION + ": " + response);
+            return null;
+        }
+
+        return result.get(Util.ACCESS_CONTROL);
+    }
+
+    private static void setAddress(ModelNode request, String[] parent, OperationRequestAddress address) {
+        final ModelNode addressNode = request.get(Util.ADDRESS);
+        addressNode.setEmptyList();
+        if(parent != null) {
+            int i = 0;
+            while(i < parent.length) {
+                addressNode.add(parent[i++], parent[i++]);
+            }
+        }
+
+        if(!address.isEmpty()) {
+            final Iterator<Node> iterator = address.iterator();
+            while (iterator.hasNext()) {
+                final OperationRequestAddress.Node node = iterator.next();
+                if (node.getName() != null) {
+                    addressNode.add(node.getType(), node.getName());
+                } else if (iterator.hasNext()) {
+                    throw new IllegalArgumentException(
+                            "The node name is not specified for type '"
+                                    + node.getType() + "'");
+                }
+            }
+        }
+    }
+}

--- a/cli/src/main/java/org/jboss/as/cli/accesscontrol/ControllerModeAccess.java
+++ b/cli/src/main/java/org/jboss/as/cli/accesscontrol/ControllerModeAccess.java
@@ -1,0 +1,66 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.cli.accesscontrol;
+
+import org.jboss.as.cli.CommandContext;
+
+/**
+ * @author Alexey Loubyansky
+ *
+ */
+public class ControllerModeAccess extends BaseAccessRequirement {
+
+    public enum Mode {
+        DOMAIN, STANDALONE
+    }
+
+    private final Mode mode;
+    private AccessRequirement requirement = AccessRequirement.NONE;
+
+    ControllerModeAccess(Mode mode) {
+        if(mode == null) {
+            throw new IllegalArgumentException("mode is null");
+        }
+        this.mode = mode;
+    }
+
+    public void setRequirement(AccessRequirement requirement) {
+        if(requirement == null) {
+            throw new IllegalArgumentException("Requirement is null");
+        }
+        this.requirement = requirement;
+    }
+
+    @Override
+    protected boolean checkAccess(CommandContext ctx) {
+        if(ctx.isDomainMode()) {
+            return mode == Mode.DOMAIN ? requirement.isSatisfied(ctx) : false;
+        }
+        return mode == Mode.STANDALONE ? requirement.isSatisfied(ctx) : false;
+    }
+
+    @Override
+    public String toString() {
+        return mode + " " + requirement;
+    }
+}

--- a/cli/src/main/java/org/jboss/as/cli/accesscontrol/HostServerOperationAccess.java
+++ b/cli/src/main/java/org/jboss/as/cli/accesscontrol/HostServerOperationAccess.java
@@ -1,0 +1,185 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.cli.accesscontrol;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.jboss.as.cli.CommandContext;
+import org.jboss.as.cli.Util;
+import org.jboss.as.cli.operation.OperationRequestAddress;
+import org.jboss.as.cli.operation.impl.DefaultOperationRequestAddress;
+import org.jboss.as.controller.client.ModelControllerClient;
+
+/**
+ * @author Alexey Loubyansky
+ *
+ */
+public class HostServerOperationAccess extends BaseOperationAccessRequirement {
+
+    private int lastCheckedServer;
+    private Map<String,List<String>> toCheck;
+    private Map<String,List<String>> allowed;
+
+    public HostServerOperationAccess(CommandContext ctx, String address, String operation) {
+        this(address, operation);
+        ctx.addEventListener(this);
+    }
+
+    HostServerOperationAccess(String address, String operation) {
+        super(address, operation);
+    }
+
+    HostServerOperationAccess(String operation) {
+        super(operation);
+    }
+
+    HostServerOperationAccess(OperationRequestAddress address, String operation) {
+        super(address, operation);
+    }
+
+    @Override
+    public void resetState() {
+        lastCheckedServer = 0;
+        toCheck = null;
+        allowed = null;
+    }
+
+    public Collection<String> getAllowedHosts(CommandContext ctx) {
+        if(allowed == null) {
+            initAllowedLists(ctx);
+        }
+        return allowed.keySet();
+    }
+
+    public Collection<String> getAllowedServers(CommandContext ctx, String host) {
+        if(allowed == null) {
+            initAllowedLists(ctx);
+        }
+        final List<String> servers = allowed.get(host);
+        return servers == null ? Collections.<String>emptyList() : servers;
+    }
+
+    protected void initAllowedLists(CommandContext ctx) {
+        if(ctx.getConfig().isAccessControl()) {
+            if(!isSatisfied(ctx)) {
+                allowed = Collections.emptyMap();
+            } else {
+                completeAccessCheck(ctx);
+            }
+        } else {
+            final ModelControllerClient client = ctx.getModelControllerClient();
+            allowed = new HashMap<String,List<String>>();
+            final OperationRequestAddress hostAddress = new DefaultOperationRequestAddress();
+            hostAddress.toNodeType(Util.HOST);
+            final List<String> hosts = Util.getNodeNames(client, null, Util.HOST);
+            for(String host : hosts) {
+                hostAddress.toNode(host);
+                final List<String> servers = Util.getNodeNames(client, hostAddress, Util.SERVER);
+                if(!servers.isEmpty()) {
+                    allowed.put(host, servers);
+                }
+            }
+        }
+    }
+
+    protected void completeAccessCheck(CommandContext ctx) {
+
+        final ModelControllerClient client = ctx.getModelControllerClient();
+        allowed = new HashMap<String,List<String>>();
+        final OperationRequestAddress hostAddress = new DefaultOperationRequestAddress();
+        hostAddress.toNodeType(Util.HOST);
+        final String[] parent = new String[4];
+        parent[0] = Util.HOST;
+        parent[2] = Util.SERVER;
+        for(Map.Entry<String, List<String>> entry : toCheck.entrySet()) {
+            final String host = entry.getKey();
+            hostAddress.toNode(host);
+            List<String> servers = entry.getValue();
+            List<String> allowedServers = null;
+            int i = 0;
+            if(servers == null) {
+                servers = Util.getNodeNames(client, hostAddress, Util.SERVER);
+            } else {
+                allowedServers = new ArrayList<String>();
+                allowed.put(host, allowedServers);
+                allowedServers.add(servers.get(lastCheckedServer));
+                i = lastCheckedServer + 1;
+            }
+            parent[1] = host;
+            while(i < servers.size()) {
+                final String server = servers.get(i++);
+                parent[3] = server;
+                if(CLIAccessControl.isExecute(client, parent, address, operation)) {
+                    if(allowedServers == null) {
+                        allowedServers = new ArrayList<String>();
+                        allowed.put(host, allowedServers);
+                    }
+                    allowedServers.add(server);
+                }
+            }
+        }
+    }
+
+    @Override
+    protected boolean checkAccess(CommandContext ctx) {
+
+        final ModelControllerClient client = ctx.getModelControllerClient();
+        final List<String> hosts = Util.getNodeNames(client, null, Util.HOST);
+        if(hosts.isEmpty()) {
+            return false;
+        }
+
+        final OperationRequestAddress hostAddress = new DefaultOperationRequestAddress();
+        hostAddress.toNodeType(Util.HOST);
+        final String[] parent = new String[4];
+        parent[0] = Util.HOST;
+        parent[2] = Util.SERVER;
+        toCheck = new HashMap<String,List<String>>();
+        boolean satisfied = false;
+        for(String host : hosts) {
+            if (!satisfied) {
+                lastCheckedServer = 0;
+                hostAddress.toNode(host);
+                parent[1] = host;
+                final List<String> servers = Util.getNodeNames(client, hostAddress, Util.SERVER);
+                for (String server : servers) {
+                    parent[3] = server;
+                    if (CLIAccessControl.isExecute(client, parent, address, operation)) {
+                        toCheck.put(host, servers);
+                        satisfied = true;
+                        break;
+                    }
+                    ++lastCheckedServer;
+                }
+            } else {
+                toCheck.put(host, null);
+            }
+        }
+        return satisfied;
+    }
+}

--- a/cli/src/main/java/org/jboss/as/cli/accesscontrol/MainOperationAccessRequirement.java
+++ b/cli/src/main/java/org/jboss/as/cli/accesscontrol/MainOperationAccessRequirement.java
@@ -1,0 +1,56 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.cli.accesscontrol;
+
+import org.jboss.as.cli.CommandContext;
+import org.jboss.as.cli.operation.OperationRequestAddress;
+import org.jboss.as.controller.client.ModelControllerClient;
+
+/**
+ * @author Alexey Loubyansky
+ *
+ */
+public class MainOperationAccessRequirement extends BaseOperationAccessRequirement {
+
+
+    MainOperationAccessRequirement(String operation) {
+        super(operation);
+    }
+
+    MainOperationAccessRequirement(String address, String operation) {
+        super(address, operation);
+    }
+
+    MainOperationAccessRequirement(OperationRequestAddress address, String operation) {
+        super(address, operation);
+    }
+
+    @Override
+    protected boolean checkAccess(CommandContext ctx) {
+        final ModelControllerClient client = ctx.getModelControllerClient();
+        if(client == null) {
+            return false;
+        }
+        return CLIAccessControl.isExecute(client, address, operation);
+    }
+}

--- a/cli/src/main/java/org/jboss/as/cli/accesscontrol/PerNodeOperationAccess.java
+++ b/cli/src/main/java/org/jboss/as/cli/accesscontrol/PerNodeOperationAccess.java
@@ -1,0 +1,161 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.cli.accesscontrol;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.jboss.as.cli.CommandContext;
+import org.jboss.as.cli.Util;
+import org.jboss.as.cli.operation.OperationRequestAddress;
+import org.jboss.as.controller.client.ModelControllerClient;
+
+/**
+ * @author Alexey Loubyansky
+ *
+ */
+public class PerNodeOperationAccess extends BaseOperationAccessRequirement {
+
+    private static final Boolean[] EMPTY_BARR = new Boolean[0];
+
+    private final String nodeType;
+    private List<String> nodeNames = Collections.emptyList();
+    private Boolean[] stateOn = null;
+    private List<String> allowedOn;
+
+    PerNodeOperationAccess(String nodeType, String operation) {
+        super(operation);
+        if(nodeType == null) {
+            throw new IllegalArgumentException(nodeType);
+        }
+        this.nodeType = nodeType;
+    }
+
+    public PerNodeOperationAccess(CommandContext ctx, String nodeType, String address, String operation) {
+        this(nodeType, address, operation);
+        ctx.addEventListener(this);
+    }
+
+    PerNodeOperationAccess(String nodeType, String address, String operation) {
+        super(address, operation);
+        if(nodeType == null) {
+            throw new IllegalArgumentException(nodeType);
+        }
+        this.nodeType = nodeType;
+    }
+
+    PerNodeOperationAccess(String nodeType, OperationRequestAddress address, String operation) {
+        super(address, operation);
+        if(nodeType == null) {
+            throw new IllegalArgumentException(nodeType);
+        }
+        this.nodeType = nodeType;
+    }
+
+    @Override
+    public void resetState() {
+        nodeNames = null;
+        stateOn = null;
+        allowedOn = null;
+    }
+
+    public List<String> getAllowedOn(CommandContext ctx) {
+        if(allowedOn == null) {
+            if (ctx.getConfig().isAccessControl()) {
+                if (stateOn == null) {
+                    initList(ctx.getModelControllerClient());
+                }
+                completeAllowedOn(ctx.getModelControllerClient());
+            } else {
+                allowedOn = Util.getNodeNames(ctx.getModelControllerClient(), null, nodeType);
+            }
+        }
+        return allowedOn;
+    }
+
+    @Override
+    protected boolean checkAccess(CommandContext ctx) {
+        final ModelControllerClient client = ctx.getModelControllerClient();
+        if(client == null) {
+            return false;
+        }
+        if(!ctx.isDomainMode()) {
+            return false;
+        }
+        return initList(client);
+    }
+
+    @Override
+    public String toString() {
+        if(toString == null) {
+            final StringBuilder buf = new StringBuilder();
+            buf.append(nodeType).append("=*").append(super.toString());
+            toString = buf.toString();
+        }
+        return toString;
+    }
+
+    protected boolean initList(ModelControllerClient client) {
+        nodeNames = Util.getNodeNames(client, null, nodeType);
+        if(nodeNames.isEmpty()) {
+            allowedOn = nodeNames;
+            stateOn = EMPTY_BARR;
+            return false;
+        }
+        this.stateOn = new Boolean[nodeNames.size()];
+        final String[] parent = new String[2];
+        parent[0] = nodeType;
+        for(int i = 0; i < nodeNames.size(); ++i) {
+            parent[1] = nodeNames.get(i);
+            if(CLIAccessControl.isExecute(client, parent, address, operation)) {
+                stateOn[i] = true;
+                return true;
+            } else {
+                stateOn[i] = false;
+            }
+        }
+        return false;
+    }
+
+    protected void completeAllowedOn(ModelControllerClient client) {
+        if(nodeNames.isEmpty()) {
+            allowedOn = nodeNames;
+            return;
+        }
+        allowedOn = new ArrayList<String>(stateOn.length);
+        final String[] parent = new String[2];
+        parent[0] = nodeType;
+        for(int i = 0; i < stateOn.length; ++i) {
+            Boolean state = stateOn[i];
+            if(state == null) {
+                parent[1] = nodeNames.get(i);
+                state = CLIAccessControl.isExecute(client, parent, address, operation);
+                stateOn[i] = state;
+            }
+            if(state) {
+                allowedOn.add(nodeNames.get(i));
+            }
+        }
+    }
+}

--- a/cli/src/main/java/org/jboss/as/cli/handlers/BaseOperationCommand.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/BaseOperationCommand.java
@@ -35,6 +35,7 @@ import org.jboss.as.cli.CommandFormatException;
 import org.jboss.as.cli.CommandLineException;
 import org.jboss.as.cli.OperationCommand;
 import org.jboss.as.cli.Util;
+import org.jboss.as.cli.accesscontrol.AccessRequirement;
 import org.jboss.as.cli.impl.ArgumentWithValue;
 import org.jboss.as.cli.impl.HeadersArgumentValueConverter;
 import org.jboss.as.cli.impl.RequestParameterArgument;
@@ -58,15 +59,22 @@ public abstract class BaseOperationCommand extends CommandHandlerWithHelp implem
     protected OperationRequestAddress requiredAddress;
 
     private boolean dependsOnProfile;
-    private Boolean addressAvailable;
+    private Boolean available;
     private String requiredType;
 
     protected final ArgumentWithValue headers;
+
+    protected AccessRequirement accessRequirement;
 
     public BaseOperationCommand(CommandContext ctx, String command, boolean connectionRequired) {
         super(command, connectionRequired);
         ctx.addEventListener(this);
         headers = new ArgumentWithValue(this, HeadersCompleter.INSTANCE, HeadersArgumentValueConverter.INSTANCE, "--headers");
+        accessRequirement = setupAccessRequirement(ctx);
+    }
+
+    protected AccessRequirement setupAccessRequirement(CommandContext ctx) {
+        return AccessRequirement.NONE;
     }
 
     /**
@@ -129,47 +137,31 @@ public abstract class BaseOperationCommand extends CommandHandlerWithHelp implem
             return false;
         }
         if(requiredAddress == null) {
-            return true;
+            return ctx.getConfig().isAccessControl() ? accessRequirement.isSatisfied(ctx) : true;
         }
 
         if(dependsOnProfile && ctx.isDomainMode()) { // not checking address in all the profiles
-            return true;
+            return ctx.getConfig().isAccessControl() ? accessRequirement.isSatisfied(ctx) : true;
         }
 
-        if(addressAvailable != null) {
-            return addressAvailable.booleanValue();
+        if(available != null) {
+            return available.booleanValue();
         }
 
         final ModelControllerClient client = ctx.getModelControllerClient();
         if(client == null) {
             return false;
         }
-        final ModelNode request = new ModelNode();
-        final ModelNode address = request.get(Util.ADDRESS);
 
+        // caching the results of an address validation may cause a problem:
+        // the address may become valid/invalid during the session
+        // the change won't have an effect until the cache is cleared
+        // which happens on reconnect/disconnect
         if(requiredType == null) {
-            address.setEmptyList();
-            request.get(Util.OPERATION).set(Util.VALIDATE_ADDRESS);
-            final ModelNode addressValue = request.get(Util.VALUE);
-            for(OperationRequestAddress.Node node : requiredAddress) {
-                addressValue.add(node.getType(), node.getName());
-            }
-            final ModelNode response;
-            try {
-                response = ctx.getModelControllerClient().execute(request);
-            } catch (IOException e) {
-                return false;
-            }
-            final ModelNode result = response.get(Util.RESULT);
-            if(!result.isDefined()) {
-                return false;
-            }
-            final ModelNode valid = result.get(Util.VALID);
-            if(!valid.isDefined()) {
-                return false;
-            }
-            addressAvailable = valid.asBoolean();
+            available = isAddressValid(ctx);
         } else {
+            final ModelNode request = new ModelNode();
+            final ModelNode address = request.get(Util.ADDRESS);
             for(OperationRequestAddress.Node node : requiredAddress) {
                 address.add(node.getType(), node.getName());
             }
@@ -180,15 +172,45 @@ public abstract class BaseOperationCommand extends CommandHandlerWithHelp implem
             } catch (IOException e) {
                 return false;
             }
-            addressAvailable = Util.listContains(result, requiredType);
+            available = Util.listContains(result, requiredType);
         }
-        return addressAvailable;
+
+        if(ctx.getConfig().isAccessControl()) {
+            available = available && accessRequirement.isSatisfied(ctx);
+        }
+        return available;
+    }
+
+    protected boolean isAddressValid(CommandContext ctx) {
+        final ModelNode request = new ModelNode();
+        final ModelNode address = request.get(Util.ADDRESS);
+        address.setEmptyList();
+        request.get(Util.OPERATION).set(Util.VALIDATE_ADDRESS);
+        final ModelNode addressValue = request.get(Util.VALUE);
+        for(OperationRequestAddress.Node node : requiredAddress) {
+            addressValue.add(node.getType(), node.getName());
+        }
+        final ModelNode response;
+        try {
+            response = ctx.getModelControllerClient().execute(request);
+        } catch (IOException e) {
+            return false;
+        }
+        final ModelNode result = response.get(Util.RESULT);
+        if(!result.isDefined()) {
+            return false;
+        }
+        final ModelNode valid = result.get(Util.VALID);
+        if(!valid.isDefined()) {
+            return false;
+        }
+        return valid.asBoolean();
     }
 
     @Override
     public void cliEvent(CliEvent event, CommandContext ctx) {
         if(event == CliEvent.DISCONNECTED) {
-            addressAvailable = null;
+            available = null;
         }
     }
 

--- a/cli/src/main/java/org/jboss/as/cli/handlers/ReadOperationHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/ReadOperationHandler.java
@@ -72,6 +72,9 @@ public class ReadOperationHandler extends BaseOperationCommand {
                         }
                     }
                     req.get(Util.OPERATION).set(Util.READ_OPERATION_NAMES);
+                    if(ctx.getConfig().isAccessControl()) {
+                        req.get(Util.ACCESS_CONTROL).set(true);
+                    }
                     try {
                         final ModelNode response = ctx.getModelControllerClient().execute(req);
                         return Util.getList(response);
@@ -95,7 +98,11 @@ public class ReadOperationHandler extends BaseOperationCommand {
         final String name = this.name.getValue(parsedCmd);
         if(name == null || name.isEmpty()) {
             final OperationRequestAddress address = getAddress(ctx);
-            return Util.buildRequest(ctx, address, Util.READ_OPERATION_NAMES);
+            final ModelNode request = Util.buildRequest(ctx, address, Util.READ_OPERATION_NAMES);
+            if(ctx.getConfig().isAccessControl()) {
+                request.get(Util.ACCESS_CONTROL).set(true);
+            }
+            return request;
         }
 
         final OperationRequestAddress address = getAddress(ctx);

--- a/cli/src/main/java/org/jboss/as/cli/handlers/ShutdownHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/ShutdownHandler.java
@@ -24,12 +24,14 @@ package org.jboss.as.cli.handlers;
 
 import java.io.IOException;
 import java.util.Collection;
-import java.util.Collections;
 
 import org.jboss.as.cli.CommandContext;
 import org.jboss.as.cli.CommandFormatException;
 import org.jboss.as.cli.CommandLineException;
 import org.jboss.as.cli.Util;
+import org.jboss.as.cli.accesscontrol.AccessRequirement;
+import org.jboss.as.cli.accesscontrol.AccessRequirementBuilder;
+import org.jboss.as.cli.accesscontrol.PerNodeOperationAccess;
 import org.jboss.as.cli.impl.ArgumentWithValue;
 import org.jboss.as.cli.impl.CLIModelControllerClient;
 import org.jboss.as.cli.impl.CommaSeparatedCompleter;
@@ -46,6 +48,7 @@ public class ShutdownHandler extends BaseOperationCommand {
 
     private final ArgumentWithValue restart;
     private final ArgumentWithValue host;
+    private PerNodeOperationAccess hostShutdownPermission;
 
     public ShutdownHandler(CommandContext ctx) {
         super(ctx, "shutdown", true);
@@ -55,25 +58,8 @@ public class ShutdownHandler extends BaseOperationCommand {
         host = new ArgumentWithValue(this, new CommaSeparatedCompleter() {
             @Override
             protected Collection<String> getAllCandidates(CommandContext ctx) {
-                if(!ctx.isDomainMode()) {
-                    return Collections.emptyList();
-                }
-                final ModelControllerClient client = ctx.getModelControllerClient();
-                if(client == null) {
-                    return Collections.emptyList();
-                }
-                final ModelNode op = new ModelNode();
-                op.get(Util.ADDRESS).setEmptyList();
-                op.get(Util.OPERATION).set(Util.READ_CHILDREN_NAMES);
-                op.get(Util.CHILD_TYPE).set(Util.HOST);
-                try {
-                    ModelNode outcome = client.execute(op);
-                    if (Util.isSuccess(outcome)) {
-                        return Util.getList(outcome);
-                    }
-                } catch (Exception e) {
-                }
-                return Collections.emptyList();
+                return hostShutdownPermission.getAllowedOn(ctx);
+
             }} , "--host") {
             @Override
             public boolean canAppearNext(CommandContext ctx) throws CommandFormatException {
@@ -83,6 +69,15 @@ public class ShutdownHandler extends BaseOperationCommand {
                 return super.canAppearNext(ctx);
             }
         };
+    }
+
+    @Override
+    protected AccessRequirement setupAccessRequirement(CommandContext ctx) {
+        hostShutdownPermission = new PerNodeOperationAccess(ctx, Util.HOST, null, Util.RELOAD);
+        return AccessRequirementBuilder.Factory.create(ctx).any()
+                .operation(Util.RELOAD)
+                .requirement(hostShutdownPermission)
+                .build();
     }
 
     /* (non-Javadoc)
@@ -150,7 +145,7 @@ public class ShutdownHandler extends BaseOperationCommand {
             }
             op.get(Util.ADDRESS).setEmptyList();
         }
-        op.get(Util.OPERATION).set("shutdown");
+        op.get(Util.OPERATION).set(Util.SHUTDOWN);
         setBooleanArgument(args, op, restart, "restart");
         return op;
     }

--- a/cli/src/main/java/org/jboss/as/cli/impl/ArgumentWithoutValue.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/ArgumentWithoutValue.java
@@ -31,6 +31,7 @@ import org.jboss.as.cli.CommandArgument;
 import org.jboss.as.cli.CommandContext;
 import org.jboss.as.cli.CommandFormatException;
 import org.jboss.as.cli.CommandLineCompleter;
+import org.jboss.as.cli.accesscontrol.AccessRequirement;
 import org.jboss.as.cli.handlers.CommandHandlerWithArguments;
 import org.jboss.as.cli.operation.ParsedCommandLine;
 
@@ -48,6 +49,8 @@ public class ArgumentWithoutValue implements CommandArgument {
     protected List<CommandArgument> requiredPreceding;
     protected List<CommandArgument> cantAppearAfter = Collections.emptyList();
     protected boolean exclusive;
+
+    protected AccessRequirement access = AccessRequirement.NONE;
 
     public ArgumentWithoutValue(CommandHandlerWithArguments handler, String fullName) {
         this(handler, -1, fullName);
@@ -184,6 +187,10 @@ public class ArgumentWithoutValue implements CommandArgument {
     @Override
     public boolean canAppearNext(CommandContext ctx) throws CommandFormatException {
 
+        if(!access.isSatisfied(ctx)) {
+            return false;
+        }
+
         ParsedCommandLine args = ctx.getParsedCommandLine();
         if (exclusive) {
             final Set<String> propertyNames = args.getPropertyNames();
@@ -244,5 +251,12 @@ public class ArgumentWithoutValue implements CommandArgument {
     @Override
     public String getShortName() {
         return shortName;
+    }
+
+    public void setAccessRequirement(AccessRequirement access) {
+        if(access == null) {
+            throw new IllegalArgumentException("access requirement is null");
+        }
+        this.access = access;
     }
 }

--- a/cli/src/main/java/org/jboss/as/cli/impl/CliConfigImpl.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/CliConfigImpl.java
@@ -38,6 +38,7 @@ import org.jboss.as.cli.CliInitializationException;
 import org.jboss.as.cli.CommandContext;
 import org.jboss.as.cli.SSLConfig;
 import org.jboss.as.protocol.StreamUtils;
+import org.jboss.logging.Logger;
 import org.jboss.staxmapper.XMLElementReader;
 import org.jboss.staxmapper.XMLExtendedStreamReader;
 import org.jboss.staxmapper.XMLMapper;
@@ -54,6 +55,7 @@ class CliConfigImpl implements CliConfig {
     private static final String CURRENT_WORKING_DIRECTORY = "user.dir";
     private static final String JBOSS_CLI_FILE = "jboss-cli.xml";
 
+    private static final String ACCESS_CONTROL = "access-control";
     private static final String DEFAULT_CONTROLLER = "default-controller";
     private static final String ENABLED = "enabled";
     private static final String FILE_DIR = "file-dir";
@@ -68,6 +70,8 @@ class CliConfigImpl implements CliConfig {
     private static final String RESOLVE_PARAMETER_VALUES = "resolve-parameter-values";
     private static final String SILENT = "silent";
     private static final String VALIDATE_OPERATION_REQUESTS = "validate-operation-requests";
+
+    private static final Logger log = Logger.getLogger(CliConfig.class);
 
     static CliConfig load(final CommandContext ctx) throws CliInitializationException {
         File jbossCliFile = findCLIFileFromSystemProperty();
@@ -198,6 +202,9 @@ class CliConfigImpl implements CliConfig {
 
     private boolean silent;
 
+    // TODO needs to be exposed through xml
+    private boolean accessControl = true;
+
     @Override
     public String getDefaultControllerProtocol() {
         return defaultControllerProtocol;
@@ -256,6 +263,11 @@ class CliConfigImpl implements CliConfig {
     @Override
     public boolean isSilent() {
         return silent;
+    }
+
+    @Override
+    public boolean isAccessControl() {
+        return accessControl;
     }
 
     static class SslConfig implements SSLConfig {
@@ -388,6 +400,11 @@ class CliConfigImpl implements CliConfig {
                         }
                     } else if(localName.equals(SILENT)) {
                         config.silent = resolveBoolean(reader.getElementText());
+                    } else if(localName.equals(ACCESS_CONTROL)) {
+                        config.accessControl = resolveBoolean(reader.getElementText());
+                        if(log.isTraceEnabled()) {
+                            log.trace(ACCESS_CONTROL + " is " + config.accessControl);
+                        }
                     } else {
                         throw new XMLStreamException("Unexpected element: " + localName);
                     }
@@ -518,5 +535,4 @@ class CliConfigImpl implements CliConfig {
             }
         }
     }
-
 }

--- a/cli/src/main/java/org/jboss/as/cli/impl/CommandContextImpl.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/CommandContextImpl.java
@@ -204,7 +204,7 @@ class CommandContextImpl implements CommandContext, ModelControllerClientFactory
     /** operation request address prefix */
     private final OperationRequestAddress prefix = new DefaultOperationRequestAddress();
     /** the prefix formatter */
-    private final NodePathFormatter prefixFormatter = new DefaultPrefixFormatter();
+    private final NodePathFormatter prefixFormatter = DefaultPrefixFormatter.INSTANCE;
     /** provider of operation request candidates for tab-completion */
     private final OperationCandidatesProvider operationCandidatesProvider;
     /** operation request handler */
@@ -1245,7 +1245,7 @@ class CommandContextImpl implements CommandContext, ModelControllerClientFactory
                 printLine("");
                 printLine("The connection to the controller has been closed as the result of the shutdown operation.");
                 printLine("(Although the command prompt will wrongly indicate connection until the next line is entered)");
-            }
+            } // else maybe still notify the listeners that the connection has been closed
         }
     }
 

--- a/cli/src/main/java/org/jboss/as/cli/impl/Namespace.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/Namespace.java
@@ -46,12 +46,14 @@ public enum Namespace {
 
     CLI_1_2("urn:jboss:cli:1.2"),
 
-    CLI_2_0("urn:jboss:cli:2.0");
+    CLI_2_0("urn:jboss:cli:2.0"),
+
+    CLI_2_1("urn:jboss:cli:2.1");
 
     /**
      * The current namespace version.
      */
-    public static final Namespace CURRENT = CLI_2_0;
+    public static final Namespace CURRENT = CLI_2_1;
 
     private final String name;
 

--- a/cli/src/main/java/org/jboss/as/cli/impl/PermittedCandidates.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/PermittedCandidates.java
@@ -1,0 +1,104 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.cli.impl;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import org.jboss.as.cli.CommandContext;
+import org.jboss.as.cli.accesscontrol.AccessRequirement;
+
+/**
+ * @author Alexey Loubyansky
+ *
+ */
+public abstract class PermittedCandidates implements DefaultCompleter.CandidatesProvider {
+
+    public static class ValueWithAccessRequirement {
+
+        private final String value;
+        private final AccessRequirement requirement;
+
+        public ValueWithAccessRequirement(String value, AccessRequirement requirement) {
+            if(value == null) {
+                throw new IllegalArgumentException("Value is null");
+            }
+            if(requirement == null) {
+                throw new IllegalArgumentException("access requirement is null");
+            }
+            this.value = value;
+            this.requirement = requirement;
+        }
+
+        void visit(CommandContext ctx, List<String> allowed) {
+            if(requirement.isSatisfied(ctx)) {
+                allowed.add(value);
+            }
+        }
+    }
+
+    private static class StaticPermittedCandidates extends PermittedCandidates {
+
+        private final List<ValueWithAccessRequirement> values = new ArrayList<ValueWithAccessRequirement>();
+
+        @Override
+        protected List<ValueWithAccessRequirement> getValues(CommandContext ctx) {
+            return values;
+        }
+
+        @Override
+        protected void add(ValueWithAccessRequirement value) {
+            values.add(value);
+        }
+    }
+
+    public static PermittedCandidates create(String value, AccessRequirement requirement) {
+        final PermittedCandidates provider = new StaticPermittedCandidates();
+        return provider.add(value, requirement);
+    }
+
+    protected abstract List<ValueWithAccessRequirement> getValues(CommandContext ctx);
+
+    protected abstract void add(ValueWithAccessRequirement value);
+
+    public PermittedCandidates add(String value, AccessRequirement requirement) {
+        add(new ValueWithAccessRequirement(value, requirement));
+        return this;
+    }
+
+    @Override
+    public Collection<String> getAllCandidates(CommandContext ctx) {
+        final List<String> allowed = new ArrayList<String>();
+        if(ctx.getConfig().isAccessControl()) {
+            for(ValueWithAccessRequirement value : getValues(ctx)) {
+                value.visit(ctx, allowed);
+            }
+        } else {
+            for(ValueWithAccessRequirement value : getValues(ctx)) {
+                allowed.add(value.value);
+            }
+        }
+        return allowed;
+    }
+}

--- a/cli/src/main/java/org/jboss/as/cli/operation/OperationRequestAddress.java
+++ b/cli/src/main/java/org/jboss/as/cli/operation/OperationRequestAddress.java
@@ -31,32 +31,41 @@ package org.jboss.as.cli.operation;
 public interface OperationRequestAddress extends Iterable<OperationRequestAddress.Node> {
 
     /**
-     * Appends the node type to the prefix.
-     * Note, the current prefix must end on the node name before this method
+     * Appends the node type to the current address.
+     * Note, the current address must end on a node name before this method
      * is invoked.
      *
-     * @param nodeType  the node type to append to the prefix.
+     * @param nodeType  the node type to append to the current address
      */
     void toNodeType(String nodeType);
 
     /**
-     * Appends the node name to the prefix.
-     * Note, the current prefix must end on the node type before this method
+     * Appends the node name to the current address.
+     * Note, the current address must end on a node type before this method
      * is invoked.
      *
-     * @param nodeName the node name to append to the prefix.
+     * @param nodeName the node name to append to the current address
      */
     void toNode(String nodeName);
 
     /**
-     * Appends the node to the prefix.
-     * Note, the current prefix must end on the node (i.e. node name) before
+     * Appends the node to the current address.
+     * Note, the current address must end on a node (i.e. node name) before
      * this method is invoked.
      *
-     * @param nodeType  the node type of the node to append to the prefix
-     * @param nodeName  the node name of the node to append to the prefix
+     * @param nodeType  the node type of the node to append to the current address
+     * @param nodeName  the node name of the node to append to the current address
      */
     void toNode(String nodeType, String nodeName);
+
+    /**
+     * Appends the path to the current address.
+     * Note, the current address must end on a node (i.e. node name) before
+     * this method is invoked.
+     *
+     * @param path  the path to append to the current address
+     */
+    void appendPath(OperationRequestAddress path);
 
     /**
      * Sets the current prefix to the node type of the current node,
@@ -100,6 +109,15 @@ public interface OperationRequestAddress extends Iterable<OperationRequestAddres
      * on a type or is empty.
      */
     String getNodeName();
+
+    /**
+     * Returns the number of nodes (more specifically node types, if the address
+     * ends on a type, it means the last node is not complete, but it will be
+     * counted as a node by this method).
+     *
+     * @return  the number of nodes this address consists of
+     */
+    int length();
 
     interface Node {
 

--- a/cli/src/main/java/org/jboss/as/cli/operation/impl/DefaultCallbackHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/operation/impl/DefaultCallbackHandler.java
@@ -73,8 +73,8 @@ public class DefaultCallbackHandler extends ValidatingCallbackHandler implements
     private boolean operationComplete;
     private String operationName;
     private OperationRequestAddress address;
-    private Map<String, String> props = new HashMap<String, String>();
-    private List<String> otherArgs = new ArrayList<String>();
+    private Map<String, String> props = Collections.emptyMap();
+    private List<String> otherArgs = Collections.emptyList();
     private String outputTarget;
 
     private String lastPropName;
@@ -142,8 +142,8 @@ public class DefaultCallbackHandler extends ValidatingCallbackHandler implements
         operationComplete = false;
         operationName = null;
         address = null;
-        props.clear();
-        otherArgs.clear();
+        props = Collections.emptyMap();
+        otherArgs = Collections.emptyList();
         outputTarget = null;
         lastPropName = null;
         lastPropValue = null;
@@ -328,7 +328,7 @@ public class DefaultCallbackHandler extends ValidatingCallbackHandler implements
 
     @Override
     protected void validatedPropertyName(int index, String propertyName) throws OperationFormatException {
-        props.put(propertyName, null);
+        putProperty(propertyName, null);
         lastPropName = propertyName;
         lastPropValue = null;
         separator = SEPARATOR_NONE;
@@ -361,9 +361,9 @@ public class DefaultCallbackHandler extends ValidatingCallbackHandler implements
     @Override
     protected void validatedProperty(String name, String value, int nameValueSeparatorIndex) throws OperationFormatException {
         if(name == null) {
-            otherArgs.add(value);
+            addArgument(value);
         } else {
-            props.put(name, value);
+            putProperty(name, value);
         }
         lastPropName = name;
         lastPropValue = value;
@@ -621,5 +621,19 @@ public class DefaultCallbackHandler extends ValidatingCallbackHandler implements
     @Override
     public boolean endsOnHeaderSeparator() {
         return separator == SEPARATOR_HEADER;
+    }
+
+    private void putProperty(String key, String name) {
+        if(props.isEmpty()) {
+            props = new HashMap<String,String>();
+        }
+        props.put(key, name);
+    }
+
+    private void addArgument(String value) {
+        if(otherArgs.isEmpty()) {
+            otherArgs = new ArrayList<String>();
+        }
+        otherArgs.add(value);
     }
 }

--- a/cli/src/main/java/org/jboss/as/cli/operation/impl/DefaultOperationCandidatesProvider.java
+++ b/cli/src/main/java/org/jboss/as/cli/operation/impl/DefaultOperationCandidatesProvider.java
@@ -156,38 +156,7 @@ public class DefaultOperationCandidatesProvider implements OperationCandidatesPr
 
     @Override
     public List<String> getOperationNames(CommandContext ctx, OperationRequestAddress prefix) {
-
-        ModelControllerClient client = ctx.getModelControllerClient();
-        if(client == null) {
-            return Collections.emptyList();
-        }
-
-        if(prefix.endsOnType()) {
-            throw new IllegalArgumentException("The prefix isn't expected to end on a type.");
-        }
-
-        ModelNode request;
-        DefaultOperationRequestBuilder builder = new DefaultOperationRequestBuilder(prefix);
-        try {
-            builder.setOperationName(Util.READ_OPERATION_NAMES);
-            request = builder.buildRequest();
-        } catch (OperationFormatException e1) {
-            throw new IllegalStateException("Failed to build operation", e1);
-        }
-
-        List<String> result;
-        try {
-            ModelNode outcome = client.execute(request);
-            if (!Util.isSuccess(outcome)) {
-                // TODO logging... exception?
-                result = Collections.emptyList();
-            } else {
-                result = Util.getList(outcome);
-            }
-        } catch (Exception e) {
-            result = Collections.emptyList();
-        }
-        return result;
+        return Util.getOperationNames(ctx, prefix);
     }
 
     @Override

--- a/cli/src/main/java/org/jboss/as/cli/operation/impl/DefaultOperationRequestBuilder.java
+++ b/cli/src/main/java/org/jboss/as/cli/operation/impl/DefaultOperationRequestBuilder.java
@@ -77,7 +77,7 @@ public class DefaultOperationRequestBuilder implements OperationRequestBuilder {
             }
         }
 
-        if(!request.hasDefined("operation")) {
+        if(!request.hasDefined(Util.OPERATION)) {
             throw new OperationFormatException("The operation name is missing or the format of the operation request is wrong.");
         }
 
@@ -86,7 +86,7 @@ public class DefaultOperationRequestBuilder implements OperationRequestBuilder {
 
     @Override
     public void setOperationName(String name) {
-        request.get("operation").set(name);
+        request.get(Util.OPERATION).set(name);
     }
 
     @Override

--- a/cli/src/main/java/org/jboss/as/cli/operation/impl/DefaultPrefixFormatter.java
+++ b/cli/src/main/java/org/jboss/as/cli/operation/impl/DefaultPrefixFormatter.java
@@ -33,6 +33,8 @@ import org.jboss.as.cli.operation.OperationRequestAddress.Node;
  */
 public class DefaultPrefixFormatter implements NodePathFormatter {
 
+    public static final NodePathFormatter INSTANCE = new DefaultPrefixFormatter();
+
     /* (non-Javadoc)
      * @see org.jboss.as.cli.PrefixFormatter#format(org.jboss.as.cli.Prefix)
      */

--- a/cli/src/main/java/org/jboss/as/cli/operation/impl/OperationNameCompleter.java
+++ b/cli/src/main/java/org/jboss/as/cli/operation/impl/OperationNameCompleter.java
@@ -48,6 +48,9 @@ public class OperationNameCompleter extends DefaultCompleter {
                     addrNode.add(node.getType(), node.getName());
                 }
                 req.get(Util.OPERATION).set(Util.READ_OPERATION_NAMES);
+                if(ctx.getConfig().isAccessControl()) {
+                    req.get(Util.ACCESS_CONTROL).set(true);
+                }
                 final ModelNode response;
                 try {
                     response = ctx.getModelControllerClient().execute(req);

--- a/cli/src/test/java/org/jboss/as/cli/completion/mock/MockCliConfig.java
+++ b/cli/src/test/java/org/jboss/as/cli/completion/mock/MockCliConfig.java
@@ -90,4 +90,9 @@ public class MockCliConfig implements CliConfig {
     public boolean isSilent() {
         return false;
     }
+
+    @Override
+    public boolean isAccessControl() {
+        return false;
+    }
 }

--- a/cli/src/test/java/org/jboss/as/cli/completion/mock/MockCommandContext.java
+++ b/cli/src/test/java/org/jboss/as/cli/completion/mock/MockCommandContext.java
@@ -57,7 +57,6 @@ public class MockCommandContext implements CommandContext {
     private ModelControllerClient mcc;
     //private CommandLineParser operationParser;
     private OperationRequestAddress prefix;
-    private NodePathFormatter prefixFormatter;
     private OperationCandidatesProvider operationCandidatesProvider;
 
     private DefaultCallbackHandler parsedCmd = new DefaultCallbackHandler();
@@ -165,10 +164,7 @@ public class MockCommandContext implements CommandContext {
      */
     @Override
     public NodePathFormatter getNodePathFormatter() {
-        if(prefixFormatter == null) {
-            prefixFormatter = new DefaultPrefixFormatter();
-        }
-        return prefixFormatter;
+        return DefaultPrefixFormatter.INSTANCE;
     }
 
     /* (non-Javadoc)


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-2119

This targets
- most of the commands (except the very general ones like read-attribute, read-operation, cd);
- some command arguments and suggested values (e.g. when offered to choose target hosts, servers, server-groups and profiles, those of them for which the user has no permissions, won't be suggested, or suggested actions may be limited, e.g. a user may only be able to deploy/undeploy existing application, but not add new and remove existing, etc).

For optimization of checking the permissions, the checks where possible are made on demand instead of ahead and are cached. The cache is cleared when the CLI disconnects (or reconnects) to the controller.

The feature is configurable in the jboss-cli.xml using access-control element and, atm, is disabled by default.

Alexey
