### PR TITLE
Move jsf-impl version to 3.0.0.SP01 in the EE 9 feature pack

### DIFF
--- a/ee-9/feature-pack/pom.xml
+++ b/ee-9/feature-pack/pom.xml
@@ -52,6 +52,7 @@
         <full.ee-9-api.license.directory>${basedir}/src/license</full.ee-9-api.license.directory>
 
 
+        <version.com.sun.faces>3.0.0.SP01</version.com.sun.faces>
         <version.com.sun.activation.jakarta.activation>2.0.0-RC3</version.com.sun.activation.jakarta.activation>
         <version.jakarta.annotation.jakarta-annotation-api>2.0.0-RC1</version.jakarta.annotation.jakarta-annotation-api>
         <version.jakarta.authorization.jakarta-authorization-api>2.0.0-RC1</version.jakarta.authorization.jakarta-authorization-api>
@@ -872,6 +873,12 @@
                     <artifactId>*</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>com.sun.faces</groupId>
+            <artifactId>jsf-impl</artifactId>
+            <version>${version.com.sun.faces}</version>
         </dependency>
 
         <!--<dependency>


### PR DESCRIPTION
3.0.0.SP01 is based off the upstream org.glassfish:jakarta.faces:3.0.0-RC3 version.

This fix resolves the JSF related [issue](http://pastebin.test.redhat.com/891904) that was occurring when running [LongRunningConversationPropagatedByFacesContextTest](https://github.com/eclipse-ee4j/cdi-tck/blob/master/impl/src/main/java/org/jboss/cdi/tck/tests/context/conversation/LongRunningConversationPropagatedByFacesContextTest.java#L117).