### PR TITLE
Upgrade to Galleon plugins 5.0.0.Alpha4, transformation only occurs during FP build

### DIFF
--- a/ee-9/build/pom.xml
+++ b/ee-9/build/pom.xml
@@ -92,6 +92,8 @@
                             </feature-packs>
                             <plugin-options>
                                 <jboss-maven-dist/>
+                                <jboss-jakarta-transform-artifacts>false</jboss-jakarta-transform-artifacts>
+                                <jboss-maven-provisioning-repo>${project.basedir}/../feature-pack/target/jakarta-transform-maven-repo</jboss-maven-provisioning-repo>
                                 <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                             </plugin-options>
                         </configuration>

--- a/ee-9/dist/pom.xml
+++ b/ee-9/dist/pom.xml
@@ -90,6 +90,8 @@
                             <offline>true</offline>
                             <plugin-options>
                                 <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
+                                <jboss-maven-provisioning-repo>${project.basedir}/../feature-pack/target/jakarta-transform-maven-repo</jboss-maven-provisioning-repo>
+                                <jboss-jakarta-transform-artifacts>false</jboss-jakarta-transform-artifacts>                               
                             </plugin-options>
                             <feature-packs>
                                 <feature-pack>

--- a/ee-9/pom.xml
+++ b/ee-9/pom.xml
@@ -42,7 +42,7 @@
     <packaging>pom</packaging>
 
     <modules>
-        <!--<module>build</module>-->
+        <module>build</module>
         <module>deployment-transformer</module>
         <module>dist</module>
         <module>feature-pack</module>

--- a/pom.xml
+++ b/pom.xml
@@ -232,7 +232,7 @@
         <version.org.wildfly.checkstyle-config>1.0.8.Final</version.org.wildfly.checkstyle-config>
         <version.org.wildfly.common>1.5.2.Final</version.org.wildfly.common>
         <version.org.wildfly.component-matrix-plugin>1.0.3.Final</version.org.wildfly.component-matrix-plugin>
-        <version.org.wildfly.galleon-plugins>5.0.0.Alpha3</version.org.wildfly.galleon-plugins>
+        <version.org.wildfly.galleon-plugins>5.0.0.Alpha4</version.org.wildfly.galleon-plugins>
         <version.org.wildfly.maven.plugins>2.2.0.Final</version.org.wildfly.maven.plugins>
         <version.org.wildfly.plugin>2.0.1.Final</version.org.wildfly.plugin>
         <version.verifier.plugin>1.1</version.verifier.plugin>
@@ -9664,6 +9664,7 @@
                 <!-- No separate web dist -->
                 <wildfly.web.build.output.dir>${wildfly.build.output.dir}</wildfly.web.build.output.dir>
                 <testsuite.ee.galleon.pack.artifactId>wildfly-ee-9-galleon-pack</testsuite.ee.galleon.pack.artifactId>
+                <wildfly.transformed.repo.dir>${jbossas.project.dir}/ee-9/feature-pack/target/jakarta-transform-maven-repo</wildfly.transformed.repo.dir>
             </properties>
             <build>
                 <plugins>

--- a/testsuite/integration/smoke/pom.xml
+++ b/testsuite/integration/smoke/pom.xml
@@ -815,9 +815,9 @@
                                 </goals>
                                 <phase>generate-resources</phase>
                                 <configuration>
-                                    <!-- Override to drop the jboss-maven-dist plugin option -->
-                                    <plugin-options combine.self="override">
-                                        <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
+                                    <plugin-options combine.self="append">
+                                        <jboss-jakarta-transform-artifacts>false</jboss-jakarta-transform-artifacts>
+                                        <jboss-maven-provisioning-repo>${wildfly.transformed.repo.dir}</jboss-maven-provisioning-repo>
                                     </plugin-options>
                                 </configuration>
                             </execution>
@@ -832,6 +832,9 @@
                                 <id>default-test</id>
                                 <phase>test</phase>
                                 <configuration>
+                                     <systemPropertyVariables>
+                                        <server.jvm.args>-Dmaven.repo.local=${wildfly.transformed.repo.dir}</server.jvm.args>
+                                    </systemPropertyVariables>
                                     <excludes>
                                         <!-- Requires legacy security -->
                                         <exclude>org/jboss/as/test/smoke/mgmt/resourceadapter/ResourceAdapterOperationsUnitTestCase.java</exclude>


### PR DESCRIPTION
* Transform only once the artifacts when building the FP. Create a LOCAL_CACHE=ee-9/feature-pack/target/jakarta-transform-maven-repo

* ee-9/build is enabled, slim server that uses LOCAL_CACHE during provisioning. Requires JAVA_OPTS=-Dmaven.repo.local=LOCAL_CACHE to launch it.

* ee-9/dist fat server uses LOCAL_CACHE during provisioning, transformation is disabled.

* Running tests: -Dts.ee9 -Dts.basic. The smoke tests is back to be slim, uses LOCAL_CACHE for provisioning, transformation is disabled, surefire uses -Dmaven.repo.local=LOCAL_CACHE.
