### PR TITLE
Decoupling Batavia Implementation from Galleon Plugins

### DIFF
--- a/ee-9/feature-pack/pom.xml
+++ b/ee-9/feature-pack/pom.xml
@@ -251,6 +251,18 @@
                         </configuration>
                     </execution>
                 </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.wildfly.extras.batavia</groupId>
+                        <artifactId>transformer-api</artifactId>
+                        <version>${version.org.wildfly.extras.batavia}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.wildfly.extras.batavia</groupId>
+                        <artifactId>transformer-impl-eclipse</artifactId>
+                        <version>${version.org.wildfly.extras.batavia}</version>
+                    </dependency>
+                </dependencies>
             </plugin>
         </plugins>
     </build>
@@ -326,6 +338,30 @@
         <dependency>
             <groupId>${ee.maven.groupId}</groupId>
             <artifactId>wildfly-ee-9-deployment-transformer</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.wildfly.extras.batavia</groupId>
+            <artifactId>transformer-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.wildfly.extras.batavia</groupId>
+            <artifactId>transformer-impl-eclipse</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>biz.aQute.bnd</groupId>
+            <artifactId>biz.aQute.bnd.transform</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.eclipse.transformer</groupId>
+            <artifactId>org.eclipse.transformer</artifactId>
             <scope>provided</scope>
         </dependency>
 

--- a/ee-9/feature-pack/src/main/resources/modules/system/layers/base/org/eclipse/transformer/main/module.xml
+++ b/ee-9/feature-pack/src/main/resources/modules/system/layers/base/org/eclipse/transformer/main/module.xml
@@ -22,15 +22,16 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.wildfly.deployment.transformation">
+<module xmlns="urn:jboss:module:1.5" name="org.eclipse.transformer">
+
     <dependencies>
-        <module name="org.jboss.as.server"/>
-        <module name="org.jboss.logging"/>
-        <module name="org.wildfly.extras.batavia"/>
+        <module name="org.slf4j"/>
+        <module name="org.apache.commons.cli"/>
     </dependencies>
 
     <resources>
-        <artifact name="${org.wildfly:wildfly-ee-9-deployment-transformer}"/>
-        <artifact name="${org.wildfly.galleon-plugins:transformer}"/>
+        <artifact name="${org.eclipse.transformer:org.eclipse.transformer}"/>
+        <artifact name="${biz.aQute.bnd:biz.aQute.bnd.transform}"/>
     </resources>
+
 </module>

--- a/ee-9/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extras/batavia/main/module.xml
+++ b/ee-9/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extras/batavia/main/module.xml
@@ -22,15 +22,15 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.wildfly.deployment.transformation">
+<module xmlns="urn:jboss:module:1.5" name="org.wildfly.extras.batavia">
+
     <dependencies>
-        <module name="org.jboss.as.server"/>
-        <module name="org.jboss.logging"/>
-        <module name="org.wildfly.extras.batavia"/>
+        <module name="org.eclipse.transformer"/>
     </dependencies>
 
     <resources>
-        <artifact name="${org.wildfly:wildfly-ee-9-deployment-transformer}"/>
-        <artifact name="${org.wildfly.galleon-plugins:transformer}"/>
+        <artifact name="${org.wildfly.extras.batavia:transformer-api}"/>
+        <artifact name="${org.wildfly.extras.batavia:transformer-impl-eclipse}"/>
     </resources>
+
 </module>

--- a/pom.xml
+++ b/pom.xml
@@ -233,7 +233,7 @@
         <version.org.wildfly.checkstyle-config>1.0.8.Final</version.org.wildfly.checkstyle-config>
         <version.org.wildfly.common>1.5.2.Final</version.org.wildfly.common>
         <version.org.wildfly.component-matrix-plugin>1.0.3.Final</version.org.wildfly.component-matrix-plugin>
-        <version.org.wildfly.galleon-plugins>5.0.0.Alpha4</version.org.wildfly.galleon-plugins>
+        <version.org.wildfly.galleon-plugins>5.0.0.Alpha5-SNAPSHOT</version.org.wildfly.galleon-plugins>
         <version.org.wildfly.maven.plugins>2.2.0.Final</version.org.wildfly.maven.plugins>
         <version.org.wildfly.plugin>2.0.1.Final</version.org.wildfly.plugin>
         <version.verifier.plugin>1.1</version.verifier.plugin>
@@ -255,6 +255,7 @@
              mvn com.github.ekryd.sortpom:sortpom-maven-plugin:2.8.0:sort -Dsort.sortProperties=true -Dsort.nrOfIndentSpace=4 -Dsort.keepBlankLines=true -Dsort.sortDependencies=scope,groupId,artifactId
          -->
         <version.antlr>2.7.7</version.antlr>
+        <version.biz.aQute.bnd.transform>5.2.0</version.biz.aQute.bnd.transform>
         <version.com.beust>1.78</version.com.beust>
         <version.com.fasterxml.classmate>1.5.1</version.com.fasterxml.classmate>
         <version.com.fasterxml.jackson>2.11.3</version.com.fasterxml.jackson>
@@ -357,6 +358,7 @@
         <version.org.eclipse.microprofile.openapi.api>1.1.2</version.org.eclipse.microprofile.openapi.api>
         <version.org.eclipse.microprofile.opentracing>1.3.3</version.org.eclipse.microprofile.opentracing>
         <version.org.eclipse.microprofile.rest.client.api>1.4.0</version.org.eclipse.microprofile.rest.client.api>
+        <version.org.eclipse.transformer>0.2.0</version.org.eclipse.transformer>
         <version.org.eclipse.yasson>1.0.5</version.org.eclipse.yasson>
         <version.org.eclipselink.version>2.7.3</version.org.eclipselink.version>
         <version.org.glassfish.jakarta.el>3.0.3.jbossorg-2</version.org.glassfish.jakarta.el>
@@ -448,6 +450,7 @@
         <version.org.wildfly.arquillian>2.2.0.Final</version.org.wildfly.arquillian>
         <version.org.wildfly.core>14.0.0.Beta1</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.1</version.org.wildfly.extras.creaper>
+        <version.org.wildfly.extras.batavia>1.0.1.Final</version.org.wildfly.extras.batavia>
         <version.org.wildfly.http-client>1.1.2.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>1.0.13.Final</version.org.wildfly.naming-client>
         <version.org.wildfly.transaction.client>1.1.13.Final</version.org.wildfly.transaction.client>
@@ -1511,6 +1514,18 @@
                 <groupId>antlr</groupId>
                 <artifactId>antlr</artifactId>
                 <version>${version.antlr}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>biz.aQute.bnd</groupId>
+                <artifactId>biz.aQute.bnd.transform</artifactId>
+                <version>${version.biz.aQute.bnd.transform}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>
@@ -5696,6 +5711,18 @@
             </dependency>
 
             <dependency>
+                <groupId>org.eclipse.transformer</groupId>
+                <artifactId>org.eclipse.transformer</artifactId>
+                <version>${version.org.eclipse.transformer}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
                 <groupId>org.eclipse</groupId>
                 <artifactId>yasson</artifactId>
                 <version>${version.org.eclipse.yasson}</version>
@@ -8772,6 +8799,30 @@
                 <groupId>org.wildfly.extras.creaper</groupId>
                 <artifactId>creaper-commands</artifactId>
                 <version>${version.org.wildfly.extras.creaper}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.wildfly.extras.batavia</groupId>
+                <artifactId>transformer-api</artifactId>
+                <version>${version.org.wildfly.extras.batavia}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>org.wildfly.extras.batavia</groupId>
+                <artifactId>transformer-impl-eclipse</artifactId>
+                <version>${version.org.wildfly.extras.batavia}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
This PR @bstansberry decouples Batavia implementation  from Galleon Plugins.
Next releases of Galleon Plugins will refer only to Batavia's transformer-api dependency
(with scope provided) so it is goal of WildFly (target container) to set up properly all
Batavia transformer dependencies.

This PR when effective will allow us to upgrade Batavia's fixes directly without any need
to release Galleon Plugins. It will also allow us to test Batavia's changes more easily.

This PR follows up on https://github.com/wildfly/galleon-plugins/pull/177 