### PR TITLE
[WFLY-16297] Ensure the CLI commands to configure the server are run …

### DIFF
--- a/testsuite/integration/elytron/enable-elytron.cli
+++ b/testsuite/integration/elytron/enable-elytron.cli
@@ -1,8 +1,37 @@
 embed-server --admin-only=true --server-config=standalone-full.xml
 
 /subsystem=batch-jberet:write-attribute(name=security-domain, value=ApplicationDomain)
-/subsystem=messaging-activemq/server=default:undefine-attribute(name=security-domain)
-/subsystem=messaging-activemq/server=default:write-attribute(name=elytron-domain, value=ApplicationDomain)
+
+# Check if the default server exists, if it does we can updated if not we need to add it
+if (outcome == success) of /subsystem=messaging-activemq/server=default:read-resource
+    /subsystem=messaging-activemq/server=default:undefine-attribute(name=security-domain)
+    /subsystem=messaging-activemq/server=default:write-attribute(name=elytron-domain, value=ApplicationDomain)
+else
+    # Add the server
+    # Remove the default configuration
+    /subsystem=messaging-activemq/pooled-connection-factory=activemq-ra:remove
+    /subsystem=messaging-activemq/remote-connector=artemis:remove
+
+    # Add the default server which was in previous versions of WildFly
+    /subsystem=messaging-activemq/server=default:add(elytron-domain=ApplicationDomain, statistics-enabled="${wildfly.messaging-activemq.statistics-enabled:${wildfly.statistics-enabled:false}}")
+    /subsystem=messaging-activemq/server=default/security-setting=#:add()
+    /subsystem=messaging-activemq/server=default/security-setting=#/role=guest:add(send=true, consume=true,create-non-durable-queue=true, delete-non-durable-queue=true)
+    /subsystem=messaging-activemq/server=default/address-setting=#:add(dead-letter-address="jms.queue.DLQ", expiry-address="jms.queue.ExpiryQueue", max-size-bytes="10485760", page-size-bytes="2097152", message-counter-history-day-limit=10)
+    /subsystem=messaging-activemq/server=default/http-acceptor=http-acceptor:add(http-listener=default)
+    /subsystem=messaging-activemq/server=default/http-acceptor=http-acceptor-throughput:add(http-listener=default)
+    /subsystem=messaging-activemq/server=default/http-acceptor=http-acceptor-throughput:write-attribute(name=params.batch-delay, value=50)
+    /subsystem=messaging-activemq/server=default/http-acceptor=http-acceptor-throughput:write-attribute(name=params.direct-deliver, value=false)
+    /subsystem=messaging-activemq/server=default/in-vm-acceptor=in-vm:add(server-id=0, params={buffer-pooling=false})
+    /subsystem=messaging-activemq/server=default/in-vm-connector=in-vm:add(server-id=0, params={buffer-pooling=false})
+    /subsystem=messaging-activemq/server=default/http-connector=http-connector:add(socket-binding=http, endpoint=http-acceptor)
+    /subsystem=messaging-activemq/server=default/http-connector=http-connector-throughput:add(socket-binding=http, endpoint=http-acceptor-throughput, params={batch-delay=50})
+    /subsystem=messaging-activemq/server=default/jms-queue=ExpiryQueue:add(entries=[java:/jms/queue/ExpiryQueue])
+    /subsystem=messaging-activemq/server=default/jms-queue=DLQ:add(entries=[java:/jms/queue/DLQ])
+    /subsystem=messaging-activemq/server=default/connection-factory=InVmConnectionFactory:add(connectors=[in-vm],entries=[java:/ConnectionFactory])
+    /subsystem=messaging-activemq/server=default/connection-factory=RemoteConnectionFactory:add(connectors=[http-connector], entries=[java:jboss/exported/jms/RemoteConnectionFactory])
+    /subsystem=messaging-activemq/server=default/pooled-connection-factory=activemq-ra:add(entries=["java:/JmsXA", "java:jboss/DefaultJMSConnectionFactory"], connectors=[in-vm], transaction=xa)
+end-if
+
 /subsystem=iiop-openjdk:write-attribute(name=security, value=elytron)
 
 stop-embedded-server

--- a/testsuite/integration/elytron/pom.xml
+++ b/testsuite/integration/elytron/pom.xml
@@ -923,14 +923,11 @@
                         <groupId>org.wildfly.plugins</groupId>
                         <artifactId>wildfly-maven-plugin</artifactId>
                         <version>${version.org.wildfly.plugin}</version>
-                        <executions>
-                            <execution>
-                                <phase>none</phase>
-                                <goals>
-                                    <goal>execute-commands</goal>
-                                </goals>
-                            </execution>
-                        </executions>
+                        <configuration>
+                            <system-properties>
+                                <maven.repo.local>${wildfly.transformed.repo.dir}</maven.repo.local>
+                            </system-properties>
+                        </configuration>
                     </plugin>
                     <plugin>
                         <groupId>org.jboss.galleon</groupId>
@@ -963,6 +960,8 @@
                                     <systemPropertyVariables>
                                         <server.jvm.args>-Dmaven.repo.local=${wildfly.transformed.repo.dir}</server.jvm.args>
                                     </systemPropertyVariables>
+                                    <!-- These include a module to be used which currently uses javax and is not transformed -->
+                                    <excludedGroups>org.jboss.as.test.shared.categories.RequiresTransformedClass</excludedGroups>
                                 </configuration>
                             </execution>
                         </executions>

--- a/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/batch/BatchSubsystemSecurityTestCase.java
+++ b/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/batch/BatchSubsystemSecurityTestCase.java
@@ -43,6 +43,7 @@ import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.arquillian.api.ServerSetup;
 import org.jboss.as.arquillian.container.ManagementClient;
 import org.jboss.as.controller.PathAddress;
+import org.jboss.as.test.shared.CdiUtils;
 import org.jboss.as.test.shared.ServerReload;
 import org.jboss.as.test.shared.SnapshotRestoreSetupTask;
 import org.jboss.as.test.shared.TimeoutUtil;
@@ -50,7 +51,6 @@ import org.jboss.as.test.shared.integration.ejb.security.PermissionUtils;
 import org.jboss.dmr.ModelNode;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Assert;
 import org.junit.Before;
@@ -106,7 +106,7 @@ public class BatchSubsystemSecurityTestCase {
         jar.addAsManifestResource(BatchSubsystemSecurityTestCase.class.getPackage(),
                 "long-running-batchlet.xml",
                 "batch-jobs/long-running-batchlet.xml");
-        jar.addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+        jar.addAsManifestResource(CdiUtils.createBeansXml(), "beans.xml");
         jar.addAsManifestResource(PermissionUtils.createPermissionsXmlAsset(new AllPermission()), "permissions.xml");
         return jar;
     }

--- a/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/ejb/AuthenticationTestCase.java
+++ b/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/ejb/AuthenticationTestCase.java
@@ -240,7 +240,8 @@ public class AuthenticationTestCase {
         } catch (IOException e) {
             final String message = e.getMessage();
             assertTrue("Response should contain 'ELY01151: Evidence Verification Failed'", message.contains("ELY01151:"));
-            assertTrue("Response should contain 'javax.ejb.EJBException'", message.contains("javax.ejb.EJBException"));
+            assertTrue("Response should contain 'javax.ejb.EJBException' or 'jakarta.ejb.EJBException'",
+                    message.contains("javax.ejb.EJBException") || message.contains("jakarta.ejb.EJBException"));
         }
     }
 

--- a/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/jaspi/ConfiguredAdHocJaspiTestCase.java
+++ b/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/jaspi/ConfiguredAdHocJaspiTestCase.java
@@ -29,7 +29,9 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.test.shared.categories.RequiresTransformedClass;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 /**
@@ -41,6 +43,7 @@ import org.junit.runner.RunWith;
 @RunWith(Arquillian.class)
 @RunAsClient
 @ServerSetup({ ConfiguredAdHocJaspiTestCase.ServerSetup.class })
+@Category(RequiresTransformedClass.class)
 public class ConfiguredAdHocJaspiTestCase extends ConfiguredJaspiTestBase {
 
     private static final String NAME = ConfiguredAdHocJaspiTestCase.class.getSimpleName();

--- a/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/jaspi/ConfiguredJaspiTestCase.java
+++ b/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/jaspi/ConfiguredJaspiTestCase.java
@@ -26,7 +26,9 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.test.shared.categories.RequiresTransformedClass;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 /**
@@ -38,6 +40,7 @@ import org.junit.runner.RunWith;
 @RunWith(Arquillian.class)
 @RunAsClient
 @ServerSetup({ ConfiguredJaspiTestCase.ServerSetup.class })
+@Category(RequiresTransformedClass.class)
 public class ConfiguredJaspiTestCase extends ConfiguredJaspiTestBase {
 
     private static final String NAME = ConfiguredJaspiTestCase.class.getSimpleName();

--- a/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/jaspi/ConfiguredSelfValidatingJaspiTestCase.java
+++ b/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/jaspi/ConfiguredSelfValidatingJaspiTestCase.java
@@ -26,7 +26,9 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.test.shared.categories.RequiresTransformedClass;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.wildfly.security.auth.server.SecurityDomain;
 
@@ -39,6 +41,7 @@ import org.wildfly.security.auth.server.SecurityDomain;
 @RunWith(Arquillian.class)
 @RunAsClient
 @ServerSetup({ ConfiguredSelfValidatingJaspiTestCase.ServerSetup.class })
+@Category(RequiresTransformedClass.class)
 public class ConfiguredSelfValidatingJaspiTestCase extends ConfiguredJaspiTestBase {
 
     private static final String NAME = ConfiguredSelfValidatingJaspiTestCase.class.getSimpleName();

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/CdiUtils.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/CdiUtils.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2022 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.test.shared;
+
+import org.jboss.shrinkwrap.api.asset.Asset;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class CdiUtils {
+
+    /**
+     * Creates a {@code beans.xml} file which uses a {@code bean-discovery-mode} of "all".
+     *
+     * @return a {@code beans.xml} asset
+     */
+    public static Asset createBeansXml() {
+        return new StringAsset("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                "<beans xmlns=\"https://jakarta.ee/xml/ns/jakartaee\"\n" +
+                "       xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" +
+                "       xsi:schemaLocation=\"https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd\"\n" +
+                "       version=\"3.0\" bean-discovery-mode=\"all\">\n" +
+                "</beans>");
+    }
+}

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/categories/RequiresTransformedClass.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/categories/RequiresTransformedClass.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2022 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.test.shared.categories;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public interface RequiresTransformedClass {
+}


### PR DESCRIPTION
…against the correct maven repository. Update the scripts to add a default ActiveMQ server if missing. Skip the JASAPI tests as they require a module which is not transformed.

https://issues.redhat.com/browse/WFLY-16297