### PR TITLE
Fix test failures for WFLY-12019 to add a undertow handler for created location

### DIFF
--- a/undertow/src/main/java/org/wildfly/extension/undertow/HostRemove.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/HostRemove.java
@@ -38,18 +38,22 @@ class HostRemove extends AbstractRemoveStepHandler {
 
     @Override
     protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model) throws OperationFailedException {
-        final PathAddress address = context.getCurrentAddress();
-        final PathAddress parent = address.getParent();
-        final String name = address.getLastElement().getValue();
-        final String serverName = parent.getLastElement().getValue();
-        final ServiceName virtualHostServiceName = HostDefinition.HOST_CAPABILITY.getCapabilityServiceName(serverName, name);
-        context.removeService(virtualHostServiceName);
-        final ServiceName consoleRedirectName = UndertowService.consoleRedirectServiceName(serverName, name);
-        context.removeService(consoleRedirectName);
-        final ServiceName commonHostName = WebHost.SERVICE_NAME.append(name);
-        context.removeService(commonHostName);
-        final String defaultWebModule = HostDefinition.DEFAULT_WEB_MODULE.resolveModelAttribute(context, model).asString();
-        DefaultDeploymentMappingProvider.instance().removeMapping(defaultWebModule);
+        if (context.isResourceServiceRestartAllowed()) {
+            final PathAddress address = context.getCurrentAddress();
+            final PathAddress parent = address.getParent();
+            final String name = address.getLastElement().getValue();
+            final String serverName = parent.getLastElement().getValue();
+            final ServiceName virtualHostServiceName = HostDefinition.HOST_CAPABILITY.getCapabilityServiceName(serverName, name);
+            context.removeService(virtualHostServiceName);
+            final ServiceName consoleRedirectName = UndertowService.consoleRedirectServiceName(serverName, name);
+            context.removeService(consoleRedirectName);
+            final ServiceName commonHostName = WebHost.SERVICE_NAME.append(name);
+            context.removeService(commonHostName);
+            final String defaultWebModule = HostDefinition.DEFAULT_WEB_MODULE.resolveModelAttribute(context, model).asString();
+            DefaultDeploymentMappingProvider.instance().removeMapping(defaultWebModule);
+        } else {
+            context.reloadRequired();
+        }
     }
 
     protected void recoverServices(OperationContext context, ModelNode operation, ModelNode model) throws OperationFailedException {


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-12019

This PR tires to fix the test failures in CI that using profiles: `ts.standalone.microprofile`, `ts.layers`, `ts.bootable`, which do not have `/subsystem=undertow/configuraiton=handler/file=welcome-content` in the server configuration, that is why it failed when creating the location resource for a host.

The solution is trying to create a `/subsystem=undertow/configuraiton=handler/file=welcome` and remove it after test.