### PR TITLE
For non legacy EE User BOMs, hibernate-jpamodelgen is now hibernate-p…

### DIFF
--- a/boms/user/server/ee/legacy/pom.xml
+++ b/boms/user/server/ee/legacy/pom.xml
@@ -111,7 +111,18 @@
                                     <groupId>org.jboss.spec.jakarta.el</groupId>
                                     <artifactId>jboss-el-api_5.0_spec</artifactId>
                                 </dependency>
+                                <dependency>
+                                    <groupId>org.hibernate.orm</groupId>
+                                    <artifactId>hibernate-jpamodelgen</artifactId>
+                                </dependency>
                             </includeDependencies>
+                            <versionRefDependencies combine.children="append">
+                                <dependency>
+                                    <groupId>org.hibernate.orm</groupId>
+                                    <artifactId>hibernate-jpamodelgen</artifactId>
+                                    <version>org.hibernate.orm:hibernate-core:jar</version>
+                                </dependency>
+                            </versionRefDependencies>
                         </configuration>
                     </execution>
                 </executions>

--- a/boms/user/server/ee/pom.xml
+++ b/boms/user/server/ee/pom.xml
@@ -257,11 +257,6 @@
                                 <groupId>org.hibernate.validator</groupId>
                                 <artifactId>hibernate-validator-annotation-processor</artifactId>
                             </dependency>
-                            <!-- replaces org.hibernate:hibernate-jpamodelgen -->
-                            <dependency>
-                                <groupId>org.hibernate.orm</groupId>
-                                <artifactId>hibernate-jpamodelgen</artifactId>
-                            </dependency>
                             <!-- include ispn -->
                             <dependency>
                                 <groupId>org.infinispan</groupId>
@@ -677,7 +672,7 @@
                             </dependency>
                             <dependency>
                                 <groupId>org.hibernate.orm</groupId>
-                                <artifactId>hibernate-jpamodelgen</artifactId>
+                                <artifactId>hibernate-processor</artifactId>
                                 <version>org.hibernate.orm:hibernate-core:jar</version>
                             </dependency>
                         </versionRefDependencies>

--- a/boms/user/server/ee/preview/pom.xml
+++ b/boms/user/server/ee/preview/pom.xml
@@ -100,7 +100,19 @@
                                     <groupId>jakarta.enterprise</groupId>
                                     <artifactId>jakarta.enterprise.cdi-el-api</artifactId>
                                 </dependency>
+                                <!-- replaces org.hibernate.orm:hibernate-jpamodelgen -->
+                                <dependency>
+                                    <groupId>org.hibernate.orm</groupId>
+                                    <artifactId>hibernate-processor</artifactId>
+                                </dependency>
                             </includeDependencies>
+                            <versionRefDependencies combine.children="append">
+                                <dependency>
+                                    <groupId>org.hibernate.orm</groupId>
+                                    <artifactId>hibernate-processor</artifactId>
+                                    <version>org.hibernate.orm:hibernate-core:jar</version>
+                                </dependency>
+                            </versionRefDependencies>
                         </configuration>
                     </execution>
                 </executions>

--- a/boms/user/server/ee/standard/pom.xml
+++ b/boms/user/server/ee/standard/pom.xml
@@ -137,7 +137,19 @@
                                     <groupId>jakarta.enterprise</groupId>
                                     <artifactId>jakarta.enterprise.cdi-el-api</artifactId>
                                 </dependency>
+                                <!-- replaces org.hibernate.orm:hibernate-jpamodelgen -->
+                                <dependency>
+                                    <groupId>org.hibernate.orm</groupId>
+                                    <artifactId>hibernate-processor</artifactId>
+                                </dependency>
                             </includeDependencies>
+                            <versionRefDependencies combine.children="append">
+                                <dependency>
+                                    <groupId>org.hibernate.orm</groupId>
+                                    <artifactId>hibernate-processor</artifactId>
+                                    <version>org.hibernate.orm:hibernate-core:jar</version>
+                                </dependency>
+                            </versionRefDependencies>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
…rocessor

Maven is capable of redirecting to the new artifactId, that's why the BOM builder doesn't fail for your branch, but then it's not clear what we are adding to the BOMs.

To build QS the only change needed is due to this artifactId rename, unfortunately there Maven is not capable to redirect. I also trying to run full QS CI (some fails are expected due to the artifactId change) at https://github.com/wildfly/quickstart/pull/1156 . 